### PR TITLE
Optimize CircleFFT with butterfly, Rayon-parallel layers, and packed SIMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5699,6 +5699,7 @@ dependencies = [
  "p3-matrix",
  "p3-mersenne-31",
  "rand 0.8.5",
+ "rayon",
  "serde",
 ]
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 bytemuck = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+rayon = { workspace = true }
 
 # Plonky3 SIMD-optimized primitives
 p3-field = { workspace = true }

--- a/crates/primitives/src/circle.rs
+++ b/crates/primitives/src/circle.rs
@@ -314,6 +314,31 @@ impl CircleDomain {
         self.points.iter().all(|p| p.is_valid())
     }
     
+    /// Create a circle domain in canonic (circle-bit-reversed) order.
+    ///
+    /// In canonic order, points at indices i and i + N/2 are conjugates:
+    /// they share the same x-coordinate but have opposite y-coordinates.
+    /// This structure is required for correct Circle FFT butterfly decomposition.
+    pub fn new_canonic(log_size: usize) -> Self {
+        assert!(log_size <= 31, "Domain size exceeds circle group order");
+
+        let size = 1usize << log_size;
+        let generator = CirclePoint::generator(log_size);
+
+        // Generate sequential subgroup points: [g^0, g^1, ..., g^(n-1)]
+        let mut points = Vec::with_capacity(size);
+        let mut current = CirclePoint::IDENTITY;
+        for _ in 0..size {
+            points.push(current);
+            current = current.mul(generator);
+        }
+
+        // Apply circle bit-reverse permutation for canonic ordering
+        circle_bit_reverse_permutation(&mut points);
+
+        Self { log_size, size, generator, points }
+    }
+
     /// Get unique x-coordinates (for polynomial evaluation).
     /// Returns (unique_xs, mapping) where mapping[i] gives the index in unique_xs
     /// for domain point i.
@@ -515,12 +540,11 @@ impl CircleFFT {
 }
 
 // ============================================================================
-// Fast Circle FFT (O(n log n) Butterfly Algorithm)
+// Fast Circle FFT (O(n log n) using coset-based butterfly algorithm)
 // ============================================================================
-// Based on Stwo's proven implementation (Apache 2.0 licensed)
 
 /// Butterfly operation for forward FFT.
-/// 
+///
 /// Given v0, v1 and twiddle factor t, computes:
 /// - v0_new = v0 + v1 * t
 /// - v1_new = v0 - v1 * t
@@ -532,312 +556,402 @@ pub fn butterfly(v0: &mut M31, v1: &mut M31, twid: M31) {
 }
 
 /// Inverse butterfly operation for inverse FFT.
-/// 
+///
 /// Given v0, v1 and inverse twiddle factor it, computes:
 /// - v0_new = v0 + v1
 /// - v1_new = (v0 - v1) * it
-#[inline]  
+#[inline]
 pub fn ibutterfly(v0: &mut M31, v1: &mut M31, itwid: M31) {
     let tmp = *v0;
     *v0 = tmp + *v1;
     *v1 = (tmp - *v1) * itwid;
 }
 
-/// Precomputed twiddle factors for efficient FFT.
-/// 
-/// Twiddles are the x-coordinates of domain points, bit-reversed for
-/// efficient access during the butterfly passes.
+/// Precomputed twiddle factors for the Circle FFT.
+///
+/// Uses a "canonic coset" domain (odd coset of the subgroup) where:
+/// - Points i and i+N/2 are conjugates: same x, opposite y
+/// - No self-conjugate points exist in the coset
+///
+/// The FFT has two phases:
+/// - **Layer 0** (circle layer): butterfly with y-coordinate twiddles
+///   Decomposes f(x,y) = f₀(x) + y·f₁(x)
+/// - **Layers 1..n-1** (line layers): butterfly with x-coordinate twiddles
+///   Uses Chebyshev splitting: f(x) = f_even(2x²-1) + x·f_odd(2x²-1)
 #[derive(Clone, Debug)]
 pub struct CircleTwiddles {
-    /// Forward twiddles (x-coordinates of coset points).
-    pub twiddles: Vec<M31>,
-    /// Inverse twiddles (multiplicative inverses).
-    pub itwiddles: Vec<M31>,
-    /// Log size of the domain.
+    /// Forward twiddle factors, stored layer by layer.
+    /// Layer k has N/2^{k+1} entries. Total = N-1 entries for all n layers.
+    pub twiddles: Vec<Vec<M31>>,
+    /// Inverse twiddle factors (multiplicative inverses), stored layer by layer.
+    pub itwiddles: Vec<Vec<M31>>,
+    /// Log₂ of the full domain size N.
     pub log_size: usize,
+    /// The canonic coset domain points (N points, conjugates at i and i+N/2).
+    pub coset_points: Vec<CirclePoint>,
 }
 
 impl CircleTwiddles {
-    /// Precompute twiddle factors for a domain of size 2^log_size.
-    /// 
-    /// Follows Stwo's algorithm: for each layer, store x-coordinates
-    /// of coset points in bit-reversed order.
+    /// Precompute twiddle factors for the Circle FFT.
+    ///
+    /// Builds a canonic coset domain and computes:
+    /// - Layer 0 twiddles: y-coordinates of first N/2 coset points (bit-reversed)
+    /// - Layer k (k≥1) twiddles: x-coordinates of first half of k-times-doubled
+    ///   half-coset (bit-reversed)
     pub fn new(log_size: usize) -> Self {
         if log_size == 0 {
             return Self {
-                twiddles: vec![M31::ONE],
-                itwiddles: vec![M31::ONE],
+                twiddles: vec![],
+                itwiddles: vec![],
                 log_size,
+                coset_points: vec![CirclePoint::IDENTITY],
             };
         }
-        
-        if log_size == 1 {
-            // For size 2, we just need the y-coordinate of the generator
-            let gen = CirclePoint::generator(1);
-            return Self {
-                twiddles: vec![gen.y, M31::ONE],
-                itwiddles: vec![gen.y.inv(), M31::ONE],
-                log_size,
-            };
-        }
-        
-        // Start with a coset that generates the domain
-        // Use generator of order 2^log_size
-        let mut coset = CirclePoint::generator(log_size);
-        let mut coset_size = 1usize << log_size;
-        
-        let mut twiddles = Vec::with_capacity(coset_size);
-        
-        // For each layer, compute and store twiddles
-        // The twiddles are the x-coordinates of coset points
-        for layer in 0..log_size {
-            let start_idx = twiddles.len();
-            let half_size = coset_size / 2;
-            
-            // For each layer, collect x-coordinates of the first half of coset points
-            // Start from identity and step by generator
-            let mut point = CirclePoint::IDENTITY;
-            for _ in 0..half_size {
-                twiddles.push(point.x);
-                point = point.mul(coset);
-            }
-            
-            // Bit-reverse this layer's twiddles
-            if half_size > 1 {
-                bit_reverse_permutation(&mut twiddles[start_idx..]);
-            }
-            
-            // Double the coset generator for next layer
-            coset = coset.double();
-            coset_size /= 2;
-            
-            // After first layer, x-coordinates should all be non-zero
-            // The identity point has x=1, and we step by a generator that
-            // produces points with different x-coords
-            if layer == 0 && half_size > 0 {
-                // First layer contains identity (x=1), which is fine
-            }
-        }
-        
-        // Pad to power of 2 for alignment
-        twiddles.push(M31::ONE);
-        
-        // Compute inverse twiddles with safe fallback for any zeros
-        let itwiddles: Vec<M31> = twiddles.iter().map(|t| {
-            if t.is_zero() {
-                M31::ONE // Fallback for zero (should not happen in well-formed domains)
-            } else {
-                t.inv()
-            }
-        }).collect();
-        
-        Self { twiddles, itwiddles, log_size }
-    }
-    
-    /// Get twiddles for a specific layer.
-    fn layer_twiddles(&self, layer: usize) -> &[M31] {
-        if layer >= self.log_size {
-            return &[];
-        }
-        
-        // Calculate start index for this layer
-        let mut start = 0;
-        let mut layer_size = 1 << (self.log_size - 1);
-        for _ in 0..layer {
-            start += layer_size;
-            layer_size /= 2;
-        }
-        
-        &self.twiddles[start..(start + layer_size.max(1))]
-    }
 
-    /// Get inverse twiddles for a specific layer.
-    fn layer_itwiddles(&self, layer: usize) -> &[M31] {
-        if layer >= self.log_size {
-            return &[];
+        let n = 1usize << log_size;
+
+        // Build the canonic coset domain.
+        //
+        // The domain has N points arranged so that point i and point i+N/2
+        // are conjugates (same x, opposite y).
+        //
+        // Construction:
+        // - half_coset = {g_{4N} · g_N^k : k = 0..N/2-1}  (the "half odds" coset)
+        //   where g_m = generator of order m
+        // - Domain = half_coset ∪ conjugate(half_coset)
+        //   i.e., first N/2 points are the half coset, last N/2 are their conjugates
+        let initial = CirclePoint::generator(log_size + 2); // order 4N
+        let step = CirclePoint::generator(log_size);        // order N
+
+        let half_n = n / 2;
+
+        // Build half coset
+        let mut half_coset = Vec::with_capacity(half_n);
+        let mut current = initial;
+        for _ in 0..half_n {
+            half_coset.push(current);
+            current = current.mul(step);
         }
 
-        // Calculate start index for this layer
-        let mut start = 0;
-        let mut layer_size = 1 << (self.log_size - 1);
-        for _ in 0..layer {
-            start += layer_size;
-            layer_size /= 2;
+        // Build full domain: half_coset then conjugates
+        let mut coset_points = Vec::with_capacity(n);
+        for &p in &half_coset {
+            coset_points.push(p);
+        }
+        for &p in &half_coset {
+            coset_points.push(p.conjugate()); // (x, -y)
         }
 
-        &self.itwiddles[start..(start + layer_size.max(1))]
+        // Compute twiddles following Stwo's approach.
+        //
+        // The half_coset has N/2 points. The FFT has log_n layers total:
+        // - Layer 0 (circle): stride 1, N/2 twiddles from y-coordinates
+        // - Layer k (line, k=1..log_n-1): stride 2^k, N/2^{k+1} twiddles from x-coordinates
+        //
+        // Stwo computes line twiddles by iterating through doubling levels
+        // of the half_coset:
+        //   coset = half_coset
+        //   line_layer[0]: x-coords of first half of coset (N/4 entries)
+        //   coset = double(coset)  → N/4 points
+        //   line_layer[1]: x-coords of first half of doubled coset (N/8 entries)
+        //   ...
+        //
+        // Circle twiddles (N/2 entries) are derived from the first line layer
+        // using the coset-of-4 structure.
+        //
+        // Circle twiddles are derived from the first line layer, matching Stwo.
+
+        // Step 1: Compute line twiddles from the half_coset.
+        // At each level, take x-coords of first half, bit-reverse, then double the coset.
+        let mut line_coset = half_coset.clone();
+        let num_line_layers = if log_size > 0 { log_size - 1 } else { 0 };
+
+        let mut line_twid_layers: Vec<Vec<M31>> = Vec::with_capacity(num_line_layers);
+        let mut line_itwid_layers: Vec<Vec<M31>> = Vec::with_capacity(num_line_layers);
+
+        for _ll in 0..num_line_layers {
+            let coset_size = line_coset.len();
+            let twid_count = coset_size / 2;
+
+            let mut layer_twids: Vec<M31> =
+                line_coset[..twid_count].iter().map(|p| p.x).collect();
+            bit_reverse_permutation(&mut layer_twids);
+            let layer_itwids = batch_inverse(&layer_twids);
+
+            line_twid_layers.push(layer_twids);
+            line_itwid_layers.push(layer_itwids);
+
+            // Advance to the next doubled coset level.
+            // This is equivalent to coset = coset.double() in reference code:
+            // keep the first half of the current coset and double every point.
+            let mut next = Vec::with_capacity(twid_count);
+            for &p in line_coset.iter().take(twid_count) {
+                next.push(p.double());
+            }
+            line_coset = next;
+        }
+
+        // Step 2: Derive circle twiddles from the first line twiddle layer.
+        // In Stwo, each consecutive pair (x, y) in the first line twiddles
+        // expands to 4 circle twiddles: [y, -y, -x, x].
+        // This reflects the structure of 4-element circle cosets.
+        let mut circle_twids = Vec::with_capacity(half_n);
+        if num_line_layers > 0 && !line_twid_layers[0].is_empty() {
+            let first_line = &line_twid_layers[0];
+            for chunk in first_line.chunks(2) {
+                if chunk.len() == 2 {
+                    let x_val = chunk[0];
+                    let y_val = chunk[1];
+                    circle_twids.push(y_val);
+                    circle_twids.push(-y_val);
+                    circle_twids.push(-x_val);
+                    circle_twids.push(x_val);
+                } else {
+                    // Odd number of line twiddles — expand single
+                    let x_val = chunk[0];
+                    circle_twids.push(x_val);
+                    circle_twids.push(-x_val);
+                }
+            }
+        } else if half_n > 0 {
+            // log_size = 1: only circle layer, twiddle = y-coord of single half_coset point
+            circle_twids.push(half_coset[0].y);
+        }
+        let circle_itwids = batch_inverse(&circle_twids);
+
+        // Assemble: twiddles[0] = circle, twiddles[k] = line_twid_layers[k-1]
+        let mut twiddles = Vec::with_capacity(log_size);
+        let mut itwiddles = Vec::with_capacity(log_size);
+
+        twiddles.push(circle_twids);
+        itwiddles.push(circle_itwids);
+
+        for i in 0..num_line_layers {
+            twiddles.push(line_twid_layers[i].clone());
+            itwiddles.push(line_itwid_layers[i].clone());
+        }
+
+        Self { twiddles, itwiddles, log_size, coset_points }
     }
 }
 
-/// Fast Circle FFT implementation.
-/// 
-/// NOTE: Currently delegates to the O(n²) CircleFFT for correctness.
-/// The butterfly operations above are ready for O(n log n) implementation.
-/// 
-/// TODO: Implement proper O(n log n) butterfly-based Circle FFT.
-/// See: https://github.com/starkware-libs/stwo
+/// Batch multiplicative inverse using Montgomery's trick.
+///
+/// Computes inverses of all elements in O(n) multiplications + 1 inversion.
+/// Elements that are zero get M31::ZERO as their "inverse".
+fn batch_inverse(values: &[M31]) -> Vec<M31> {
+    let n = values.len();
+    if n == 0 {
+        return vec![];
+    }
+
+    // Forward pass: accumulate products
+    let mut prefix = Vec::with_capacity(n);
+    let mut acc = M31::ONE;
+    for &v in values {
+        if v.is_zero() {
+            prefix.push(acc);
+        } else {
+            acc = acc * v;
+            prefix.push(acc);
+        }
+    }
+
+    // Invert the accumulated product
+    let mut inv_acc = if acc.is_zero() { M31::ONE } else { acc.inv() };
+
+    // Backward pass: extract individual inverses
+    let mut result = vec![M31::ZERO; n];
+    for i in (0..n).rev() {
+        if values[i].is_zero() {
+            result[i] = M31::ZERO;
+        } else {
+            let prev = if i == 0 { M31::ONE } else { prefix[i - 1] };
+            result[i] = inv_acc * prev;
+            inv_acc = inv_acc * values[i];
+        }
+    }
+
+    result
+}
+
+/// Fast Circle FFT implementation using O(n log n) butterfly algorithm.
+///
+/// Uses the circle polynomial basis where coefficients represent:
+///   f(x,y) = Σ c_j · b_j(x,y)
+/// with basis elements b_j = y^{j₀} · x^{j₁} · (2x²-1)^{j₂} · ...
+///
+/// The domain is a canonic coset where point i and point i+N/2 are
+/// conjugates (same x, opposite y), enabling clean butterfly decomposition.
+///
+/// Coefficients are stored in bit-reversed order of the basis index.
 #[derive(Clone, Debug)]
 pub struct FastCircleFFT {
-    /// Delegate to proven implementation.
-    inner: CircleFFT,
-    #[allow(dead_code)]
+    /// Precomputed twiddle factors.
     twiddles: CircleTwiddles,
 }
 
 impl FastCircleFFT {
     /// Create a Fast Circle FFT for domain size 2^log_size.
     pub fn new(log_size: usize) -> Self {
-        Self { 
-            inner: CircleFFT::new(log_size),
-            twiddles: CircleTwiddles::new(log_size),
-        }
+        let twiddles = CircleTwiddles::new(log_size);
+        Self { twiddles }
     }
-    
-    /// Forward FFT: polynomial coefficients → evaluations.
+
+    /// Forward FFT (evaluation): circle-basis coefficients → evaluations on coset domain.
+    ///
+    /// Input: up to N coefficients in circle basis (bit-reversed order)
+    /// Output: N evaluations at the canonic coset points
+    ///
+    /// Structure (DIF - Decimation In Frequency):
+    /// 1. Line layers (log_n-1 down to 1): x-coordinate butterflies
+    /// 2. Circle layer (0): y-coordinate butterflies
     pub fn fft(&self, coeffs: &[M31]) -> Vec<M31> {
-        let n = 1 << self.twiddles.log_size;
-        let half = n / 2;
+        let log_n = self.twiddles.log_size;
+        if log_n == 0 {
+            return if coeffs.is_empty() { vec![M31::ZERO] } else { vec![coeffs[0]] };
+        }
 
-        // Pad coefficients to half domain size
-        let mut values = coeffs.to_vec();
-        values.resize(half, M31::ZERO);
+        let n = 1usize << log_n;
 
-        // Duplicate for full domain (twin points have same value for x-based polynomials)
-        values.extend(values.clone());
+        // Pad coefficients to N
+        let mut values = vec![M31::ZERO; n];
+        let copy_len = coeffs.len().min(n);
+        values[..copy_len].copy_from_slice(&coeffs[..copy_len]);
 
-        // Apply butterfly passes
-        for layer in (0..self.twiddles.log_size).rev() {
-            let layer_twiddles = self.twiddles.layer_twiddles(self.twiddles.log_size - 1 - layer);
-            let half_size = 1 << layer;
-            let num_groups = n >> (layer + 1);
+        // DIF: process from widest butterflies (high layer) to narrowest (low layer)
+        // Layer k has half_block = 2^k, block_size = 2^{k+1}, num_twiddles = N/2^{k+1}
+        //
+        // Line layers: k = log_n-1 down to 1 (x-coordinate twiddles)
+        for layer in (1..log_n).rev() {
+            let twids = &self.twiddles.twiddles[layer];
+            let half_block = 1usize << layer;
+            let block_size = half_block * 2;
 
-            for h in 0..num_groups {
-                for l in 0..half_size {
-                    let idx0 = (h << (layer + 1)) + l;
-                    let idx1 = idx0 + half_size;
-
-                    // Safety: Indices are within bounds by construction
-                    let val0 = values[idx0];
-                    let val1 = values[idx1];
-
-                    // Twiddle depends on offset l within the group
-                    let twid = layer_twiddles[l];
-
-                    // Inlined butterfly to avoid borrowing issues
-                    let tmp = val1 * twid;
-                    values[idx1] = val0 - tmp;
-                    values[idx0] = val0 + tmp;
+            for (h, &t) in twids.iter().enumerate() {
+                let base = h * block_size;
+                for l in 0..half_block {
+                    let idx0 = base + l;
+                    let idx1 = idx0 + half_block;
+                    let tmp = values[idx1] * t;
+                    values[idx1] = values[idx0] - tmp;
+                    values[idx0] = values[idx0] + tmp;
                 }
+            }
+        }
+
+        // Circle layer (layer 0): y-coordinate twiddles
+        // half_block = 1, block_size = 2, operates on pairs (2h, 2h+1)
+        {
+            let twids = &self.twiddles.twiddles[0];
+            for (h, &t) in twids.iter().enumerate() {
+                let idx0 = 2 * h;
+                let idx1 = idx0 + 1;
+                let tmp = values[idx1] * t;
+                values[idx1] = values[idx0] - tmp;
+                values[idx0] = values[idx0] + tmp;
             }
         }
 
         values
     }
-    
-    /// Inverse FFT: evaluations → polynomial coefficients.
-    pub fn ifft(&self, evals: &[M31]) -> Vec<M31> {
-        let n = 1 << self.twiddles.log_size;
-        let half = n / 2;
 
+    /// Inverse FFT (interpolation): evaluations → circle-basis coefficients.
+    ///
+    /// Input: N evaluations at the canonic coset points
+    /// Output: N coefficients in circle basis (bit-reversed order)
+    ///
+    /// Structure (DIT - Decimation In Time):
+    /// 1. Circle layer (0): y-coordinate inverse butterflies
+    /// 2. Line layers (1 up to log_n-1): x-coordinate inverse butterflies
+    /// 3. Normalize by 1/N
+    pub fn ifft(&self, evals: &[M31]) -> Vec<M31> {
+        let log_n = self.twiddles.log_size;
+        if log_n == 0 {
+            return evals.to_vec();
+        }
+
+        let n = 1usize << log_n;
         assert_eq!(evals.len(), n, "Evaluation count must match domain size");
 
         let mut values = evals.to_vec();
 
-        // Apply inverse butterfly passes
-        for layer in 0..self.twiddles.log_size {
-            let layer_itwiddles = self.twiddles.layer_itwiddles(self.twiddles.log_size - 1 - layer);
-            let half_size = 1 << layer;
-            let num_groups = n >> (layer + 1);
+        // DIT: process from narrowest butterflies (low layer) to widest (high layer)
+        // Layer k has half_block = 2^k, block_size = 2^{k+1}, num_twiddles = N/2^{k+1}
 
-            for h in 0..num_groups {
-                for l in 0..half_size {
-                    let idx0 = (h << (layer + 1)) + l;
-                    let idx1 = idx0 + half_size;
+        // Circle layer (layer 0): y-coordinate inverse twiddles on pairs (2h, 2h+1)
+        {
+            let itwids = &self.twiddles.itwiddles[0];
+            for (h, &it) in itwids.iter().enumerate() {
+                let idx0 = 2 * h;
+                let idx1 = idx0 + 1;
+                let tmp = values[idx0];
+                values[idx0] = tmp + values[idx1];
+                values[idx1] = (tmp - values[idx1]) * it;
+            }
+        }
 
-                    let val0 = values[idx0];
-                    let val1 = values[idx1];
+        // Line layers: k = 1 up to log_n-1 (x-coordinate inverse twiddles)
+        for layer in 1..log_n {
+            let itwids = &self.twiddles.itwiddles[layer];
+            let half_block = 1usize << layer;
+            let block_size = half_block * 2;
 
-                    // Twiddle depends on offset l within the group
-                    let itwid = layer_itwiddles[l];
-
-                    // Inlined ibutterfly
-                    let tmp = val0;
-                    values[idx0] = tmp + val1;
-                    values[idx1] = (tmp - val1) * itwid;
+            for (h, &it) in itwids.iter().enumerate() {
+                let base = h * block_size;
+                for l in 0..half_block {
+                    let idx0 = base + l;
+                    let idx1 = idx0 + half_block;
+                    let tmp = values[idx0];
+                    values[idx0] = tmp + values[idx1];
+                    values[idx1] = (tmp - values[idx1]) * it;
                 }
             }
         }
 
-        // Normalize by n and take first half
+        // Normalize by 1/N
         let n_inv = M31::new(n as u32).inv();
-        values.iter().take(half).map(|&v| v * n_inv).collect()
+        for v in &mut values {
+            *v = *v * n_inv;
+        }
+
+        values
     }
-    
-    /// Low-degree extension using FFT.
+
+    /// Low-degree extension: extend evaluations to a larger domain.
+    ///
+    /// Given evaluations on a coset of size N, returns evaluations
+    /// on a coset of size N · 2^log_extension.
     pub fn extend(&self, evals: &[M31], log_extension: usize) -> Vec<M31> {
-        self.inner.extend(evals, log_extension)
+        let coeffs = self.ifft(evals);
+        let ext = FastCircleFFT::new(self.log_size() + log_extension);
+        ext.fft(&coeffs) // zero-pads automatically
     }
-    
+
     /// Get domain size.
+    #[inline]
     pub fn size(&self) -> usize {
-        self.inner.size()
+        1usize << self.twiddles.log_size
     }
-    
+
     /// Get log domain size.
+    #[inline]
     pub fn log_size(&self) -> usize {
-        self.inner.log_size()
-    }
-    
-    /// Get the domain.
-    pub fn domain(&self) -> &CircleDomain {
-        self.inner.domain()
+        self.twiddles.log_size
     }
 
-    /// Get point in the domain.
+    /// Get the coset domain used by this FFT.
+    pub fn domain(&self) -> &[CirclePoint] {
+        &self.twiddles.coset_points
+    }
+
+    /// Get point in the coset domain.
+    #[inline]
     pub fn get_domain_point(&self, index: usize) -> CirclePoint {
-        self.inner.get_domain_point(index)
+        let n = self.size();
+        self.twiddles.coset_points[index % n]
     }
-}
 
-/// Execute one layer of the FFT butterfly algorithm.
-/// 
-/// This processes all butterflies at a given layer with the same twiddle factor.
-#[inline]
-fn fft_layer_loop<F>(
-    values: &mut [M31], 
-    layer: usize, 
-    h: usize, 
-    twid: M31, 
-    butterfly_fn: F
-) where F: Fn(&mut M31, &mut M31, M31) {
-    let layer_size = 1 << layer;
-    for l in 0..layer_size {
-        let idx0 = (h << (layer + 1)) + l;
-        let idx1 = idx0 + layer_size;
-        if idx1 < values.len() {
-            let (mut val0, mut val1) = (values[idx0], values[idx1]);
-            butterfly_fn(&mut val0, &mut val1, twid);
-            values[idx0] = val0;
-            values[idx1] = val1;
-        }
-    }
-}
-
-/// Compute circle twiddles (layer 0) from line twiddles (layer 1).
-/// 
-/// The relationship between consecutive domain points allows us to derive
-/// the y-coordinate twiddles from the x-coordinate twiddles.
-fn circle_twiddles_from_line(line_twiddles: &[M31]) -> impl Iterator<Item = M31> + '_ {
-    // Each pair of x-coordinates [x, y] generates circle twiddles [y, -y, -x, x]
-    line_twiddles.chunks(2).flat_map(|chunk| {
-        if chunk.len() == 2 {
-            vec![chunk[1], -chunk[1], -chunk[0], chunk[0]]
-        } else if chunk.len() == 1 {
-            vec![chunk[0]]
-        } else {
-            vec![]
-        }
-    })
 }
 
 /// Evaluate polynomial at a single point using Horner's method.
@@ -1033,9 +1147,9 @@ pub fn bit_reverse_permutation<T: Copy>(data: &mut [T]) {
     if n <= 1 {
         return;
     }
-    
+
     let log_n = n.trailing_zeros() as usize;
-    
+
     for i in 0..n {
         let j = bit_reverse(i, log_n);
         if i < j {
@@ -1047,7 +1161,51 @@ pub fn bit_reverse_permutation<T: Copy>(data: &mut [T]) {
 /// Reverse the bits of x, treating it as a log_n-bit number.
 #[inline]
 pub fn bit_reverse(x: usize, log_n: usize) -> usize {
+    if log_n == 0 {
+        return 0;
+    }
     x.reverse_bits() >> (usize::BITS as usize - log_n)
+}
+
+// ============================================================================
+// Circle Bit Reversal (for Circle FFT canonic ordering)
+// ============================================================================
+
+/// Circle-specific bit reversal: reverses bits `log_n-1..1`, keeps bit 0 fixed.
+///
+/// In canonic ordering, conjugate pairs (x, y) and (x, -y) are placed at
+/// positions i and i + N/2. This is achieved by reversing the upper bits
+/// while keeping the lowest bit (which distinguishes conjugates) fixed.
+#[inline]
+pub fn circle_bit_reverse(i: usize, log_n: usize) -> usize {
+    if log_n <= 1 {
+        return i;
+    }
+    // Split: upper bits = i >> 1, lowest bit = i & 1
+    let upper = i >> 1;
+    let lowest = i & 1;
+    // Reverse the upper (log_n - 1) bits
+    let reversed_upper = bit_reverse(upper, log_n - 1);
+    (reversed_upper << 1) | lowest
+}
+
+/// Apply circle bit-reverse permutation to a slice.
+///
+/// This reorders elements so that conjugate points end up at positions
+/// i and i + N/2 (same x, opposite y), which is required for correct
+/// Circle FFT butterfly decomposition.
+pub fn circle_bit_reverse_permutation<T: Copy>(data: &mut [T]) {
+    let n = data.len();
+    if n <= 2 {
+        return;
+    }
+    let log_n = n.trailing_zeros() as usize;
+    for i in 0..n {
+        let j = circle_bit_reverse(i, log_n);
+        if i < j {
+            data.swap(i, j);
+        }
+    }
 }
 
 // ============================================================================
@@ -1361,47 +1519,40 @@ mod tests {
     
     #[test]
     fn test_fast_fft_small_sizes() {
-        // Test size 4 (log_size 2) - smallest working size
-        let fft4 = FastCircleFFT::new(2);
-        // For size 4, we provide 2 coefficients (n/2 = 2)
-        let coeffs4 = vec![M31::new(1), M31::new(2)]; // f(x) = 1 + 2x
-        let evals4 = fft4.fft(&coeffs4);
-        assert_eq!(evals4.len(), 4, "FFT should produce 4 evaluations");
-        
-        // Test size 8 (log_size 3)
-        let fft8 = FastCircleFFT::new(3);
-        // For size 8, we provide 4 coefficients (n/2 = 4)
-        let coeffs8 = vec![M31::new(1), M31::new(2), M31::new(3), M31::new(4)];
-        let evals8 = fft8.fft(&coeffs8);
-        assert_eq!(evals8.len(), 8, "FFT should produce 8 evaluations");
+        // Test small FFT sizes produce correct output length
+        for log_size in 1..=4 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+            let coeffs: Vec<M31> = (0..n).map(|i| M31::new(i as u32 + 1)).collect();
+            let evals = fft.fft(&coeffs);
+            assert_eq!(evals.len(), n, "FFT output size mismatch for log_size {}", log_size);
+        }
     }
-    
+
     #[test]
     fn test_fast_fft_roundtrip() {
         // Test that fft followed by ifft preserves coefficients
-        // CircleFFT: fft takes n/2 coeffs -> n evals, ifft takes n evals -> n/2 coeffs
-        for log_size in 2..=5 {
+        for log_size in 1..=8 {
             let fast_fft = FastCircleFFT::new(log_size);
-            let n = 1 << log_size;
-            let half = n / 2;
-            
-            // Create test coefficients (only n/2 meaningful for degree < n/2)
-            let coeffs: Vec<M31> = (0..half).map(|i| M31::new((i * 7 + 13) as u32 % 1000)).collect();
-            
-            // Forward FFT: n/2 coeffs -> n evals
+            let n = 1usize << log_size;
+
+            // Create N test coefficients (circle basis, bit-reversed order)
+            let coeffs: Vec<M31> = (0..n).map(|i| M31::new((i * 7 + 13) as u32 % 1000)).collect();
+
+            // Forward FFT: N coeffs -> N evals
             let evals = fast_fft.fft(&coeffs);
             assert_eq!(evals.len(), n, "FFT output size mismatch for log_size {}", log_size);
-            
-            // Inverse FFT: n evals -> n/2 coeffs
+
+            // Inverse FFT: N evals -> N coeffs
             let recovered = fast_fft.ifft(&evals);
-            assert_eq!(recovered.len(), half, "IFFT output size mismatch for log_size {}", log_size);
-            
-            // Check roundtrip for the meaningful coefficients
-            for i in 0..half {
+            assert_eq!(recovered.len(), n, "IFFT output size mismatch for log_size {}", log_size);
+
+            // Check roundtrip
+            for i in 0..n {
                 assert_eq!(
-                    recovered[i], coeffs[i], 
-                    "Roundtrip failed at index {} for log_size {}: got {:?}, expected {:?}",
-                    i, log_size, recovered[i], coeffs[i]
+                    recovered[i], coeffs[i],
+                    "Roundtrip failed at index {} for log_size {}: got {}, expected {}",
+                    i, log_size, recovered[i].value(), coeffs[i].value()
                 );
             }
         }
@@ -1410,13 +1561,194 @@ mod tests {
     #[test]
     fn test_fast_fft_extend() {
         let fft = FastCircleFFT::new(3);  // size 8
-        
-        // Create coefficients (n/2 = 4 meaningful coefficients)
-        let coeffs: Vec<M31> = (0..4).map(|i| M31::new(i as u32)).collect();
+        let n = 8;
+
+        // Create N coefficients
+        let coeffs: Vec<M31> = (0..n).map(|i| M31::new(i as u32)).collect();
         let evals = fft.fft(&coeffs);
-        
+
         // Extend to size 16
         let extended = fft.extend(&evals, 1);
         assert_eq!(extended.len(), 16);
+    }
+
+    #[test]
+    fn test_coset_domain_conjugate_invariant() {
+        // Verify coset domain has conjugate pairs at i, i+N/2
+        for log_size in 1..=8 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+            let half = n / 2;
+
+            for i in 0..half {
+                let p1 = fft.get_domain_point(i);
+                let p2 = fft.get_domain_point(i + half);
+                assert_eq!(p1.x, p2.x,
+                    "Coset domain: point {} and {} should share x for log_size {}",
+                    i, i + half, log_size);
+                assert_eq!(p1.y, -p2.y,
+                    "Coset domain: point {} and {} should have opposite y for log_size {}",
+                    i, i + half, log_size);
+            }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_constant_poly() {
+        // Constant polynomial f = 42 (only c_0 nonzero)
+        for log_size in 1..=5 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+            let mut coeffs = vec![M31::ZERO; n];
+            coeffs[0] = M31::new(42);
+
+            let evals = fft.fft(&coeffs);
+
+            // Constant polynomial should evaluate to 42 everywhere
+            for (i, &e) in evals.iter().enumerate() {
+                assert_eq!(e, M31::new(42),
+                    "Constant poly eval at {} should be 42 for log_size {}, got {}",
+                    i, log_size, e.value());
+            }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_extend_consistency() {
+        // Extend via small FFT should match direct FFT on larger domain
+        for log_size in 2..=6 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+
+            // Use low-degree coefficients (fill only first half)
+            let half = n / 2;
+            let mut coeffs = vec![M31::ZERO; n];
+            for i in 0..half {
+                coeffs[i] = M31::new((i * 3 + 5) as u32 % 100);
+            }
+
+            // Path 1: fft → extend
+            let evals = fft.fft(&coeffs);
+            let extended = fft.extend(&evals, 1);
+
+            // Path 2: direct fft on larger domain with zero-padded coefficients
+            let ext_fft = FastCircleFFT::new(log_size + 1);
+            let direct_extended = ext_fft.fft(&coeffs);
+
+            // Both paths should produce identical results
+            assert_eq!(extended.len(), direct_extended.len());
+            for i in 0..extended.len() {
+                assert_eq!(extended[i], direct_extended[i],
+                    "Extend mismatch at {} for log_size {}: extend={}, direct={}",
+                    i, log_size, extended[i].value(), direct_extended[i].value());
+            }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_linearity() {
+        // FFT should be linear: fft(a*coeffs1 + b*coeffs2) = a*fft(coeffs1) + b*fft(coeffs2)
+        let fft = FastCircleFFT::new(4);
+        let n = 16;
+
+        let coeffs1: Vec<M31> = (0..n).map(|i| M31::new((i * 3 + 7) as u32 % 500)).collect();
+        let coeffs2: Vec<M31> = (0..n).map(|i| M31::new((i * 11 + 2) as u32 % 500)).collect();
+        let a = M31::new(5);
+        let b = M31::new(13);
+
+        let combined: Vec<M31> = (0..n).map(|i| a * coeffs1[i] + b * coeffs2[i]).collect();
+
+        let evals1 = fft.fft(&coeffs1);
+        let evals2 = fft.fft(&coeffs2);
+        let evals_combined = fft.fft(&combined);
+
+        for i in 0..n {
+            let expected = a * evals1[i] + b * evals2[i];
+            assert_eq!(evals_combined[i], expected,
+                "Linearity failed at {}: got {}, expected {}",
+                i, evals_combined[i].value(), expected.value());
+        }
+    }
+
+    /// Reference twiddle generation that mirrors Stwo's coset-doubling recurrence.
+    fn expected_twiddles_from_recurrence(log_size: usize) -> Vec<Vec<M31>> {
+        assert!(log_size >= 4, "reference recurrence is only used for log_size >= 4");
+
+        let n = 1usize << log_size;
+        let mut initial = CirclePoint::generator(log_size + 2);
+        let mut step = CirclePoint::generator(log_size);
+        let mut coset_size = n / 2;
+
+        let mut line_layers = Vec::with_capacity(log_size - 1);
+        for _ in 1..log_size {
+            let twid_count = coset_size / 2;
+            let mut point = initial;
+            let mut layer_twids = Vec::with_capacity(twid_count);
+
+            for _ in 0..twid_count {
+                layer_twids.push(point.x);
+                point = point.mul(step);
+            }
+            bit_reverse_permutation(&mut layer_twids);
+            line_layers.push(layer_twids);
+
+            initial = initial.double();
+            step = step.double();
+            coset_size /= 2;
+        }
+
+        let mut circle_twids = Vec::with_capacity(n / 2);
+        for chunk in line_layers[0].chunks_exact(2) {
+            let x = chunk[0];
+            let y = chunk[1];
+            circle_twids.push(y);
+            circle_twids.push(-y);
+            circle_twids.push(-x);
+            circle_twids.push(x);
+        }
+
+        let mut out = Vec::with_capacity(log_size);
+        out.push(circle_twids);
+        out.extend(line_layers);
+        out
+    }
+
+    #[test]
+    fn test_fast_fft_twiddles_match_reference_recurrence() {
+        for log_size in 4..=10 {
+            let got = CircleTwiddles::new(log_size).twiddles;
+            let expected = expected_twiddles_from_recurrence(log_size);
+            assert_eq!(got.len(), expected.len(), "layer count mismatch for log_size {log_size}");
+
+            for (layer_idx, (got_layer, expected_layer)) in
+                got.iter().zip(expected.iter()).enumerate()
+            {
+                assert_eq!(
+                    got_layer, expected_layer,
+                    "twiddle mismatch at log_size {log_size}, layer {layer_idx}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_conjugate_domain_structure() {
+        // Verify the domain has correct conjugate pairing:
+        // domain[i] and domain[i+N/2] should have same x, opposite y
+        for log_size in 1..=6 {
+            let fft = FastCircleFFT::new(log_size);
+            let domain = fft.domain();
+            let n = domain.len();
+            let half = n / 2;
+
+            for i in 0..half {
+                assert_eq!(domain[i].x, domain[i + half].x,
+                    "x-coords should match at ({}, {}) for log_size {}",
+                    i, i + half, log_size);
+                assert_eq!(domain[i].y, M31::ZERO - domain[i + half].y,
+                    "y-coords should be opposite at ({}, {}) for log_size {}",
+                    i, i + half, log_size);
+            }
+        }
     }
 }

--- a/crates/primitives/src/circle.rs
+++ b/crates/primitives/src/circle.rs
@@ -594,6 +594,8 @@ pub struct CircleTwiddles {
     pub coset_points: Vec<CirclePoint>,
 }
 
+const MAX_CANONIC_CIRCLE_LOG_SIZE: usize = 30;
+
 impl CircleTwiddles {
     /// Precompute twiddle factors for the Circle FFT.
     ///
@@ -611,6 +613,12 @@ impl CircleTwiddles {
             };
         }
 
+        assert!(
+            log_size <= MAX_CANONIC_CIRCLE_LOG_SIZE,
+            "CircleTwiddles::new only supports log_size <= {} because canonic domains require CirclePoint::generator(log_size + 1) <= 31",
+            MAX_CANONIC_CIRCLE_LOG_SIZE
+        );
+
         let n = 1usize << log_size;
 
         // Build the canonic coset domain.
@@ -619,12 +627,12 @@ impl CircleTwiddles {
         // are conjugates (same x, opposite y).
         //
         // Construction:
-        // - half_coset = {g_{4N} · g_N^k : k = 0..N/2-1}  (the "half odds" coset)
+        // - half_coset = {g_{2N} · g_{N/2}^k : k = 0..N/2-1}  (the "half odds" coset)
         //   where g_m = generator of order m
         // - Domain = half_coset ∪ conjugate(half_coset)
         //   i.e., first N/2 points are the half coset, last N/2 are their conjugates
-        let initial = CirclePoint::generator(log_size + 2); // order 4N
-        let step = CirclePoint::generator(log_size);        // order N
+        let initial = CirclePoint::generator(log_size + 1); // order 2N
+        let step = CirclePoint::generator(log_size - 1);    // order N/2
 
         let half_n = n / 2;
 
@@ -679,6 +687,7 @@ impl CircleTwiddles {
             let mut layer_twids: Vec<M31> =
                 line_coset[..twid_count].iter().map(|p| p.x).collect();
             bit_reverse_permutation(&mut layer_twids);
+            assert_nonzero_twiddles(&layer_twids, "line twiddle layer");
             let layer_itwids = batch_inverse(&layer_twids);
 
             line_twid_layers.push(layer_twids);
@@ -695,31 +704,14 @@ impl CircleTwiddles {
         }
 
         // Step 2: Derive circle twiddles from the first line twiddle layer.
-        // In Stwo, each consecutive pair (x, y) in the first line twiddles
-        // expands to 4 circle twiddles: [y, -y, -x, x].
-        // This reflects the structure of 4-element circle cosets.
-        let mut circle_twids = Vec::with_capacity(half_n);
-        if num_line_layers > 0 && !line_twid_layers[0].is_empty() {
-            let first_line = &line_twid_layers[0];
-            for chunk in first_line.chunks(2) {
-                if chunk.len() == 2 {
-                    let x_val = chunk[0];
-                    let y_val = chunk[1];
-                    circle_twids.push(y_val);
-                    circle_twids.push(-y_val);
-                    circle_twids.push(-x_val);
-                    circle_twids.push(x_val);
-                } else {
-                    // Odd number of line twiddles — expand single
-                    let x_val = chunk[0];
-                    circle_twids.push(x_val);
-                    circle_twids.push(-x_val);
-                }
-            }
-        } else if half_n > 0 {
-            // log_size = 1: only circle layer, twiddle = y-coord of single half_coset point
-            circle_twids.push(half_coset[0].y);
-        }
+        // This Stwo-style conversion only applies once the domain contains a
+        // full 4-point circle coset in bit-reversed order, i.e. log_size >= 3.
+        let circle_twids = match log_size {
+            1 => vec![half_coset[0].y],
+            2 => vec![half_coset[0].y, -half_coset[0].y],
+            _ => circle_twiddles_from_line_twiddles(&line_twid_layers[0]),
+        };
+        assert_nonzero_twiddles(&circle_twids, "circle twiddle layer");
         let circle_itwids = batch_inverse(&circle_twids);
 
         // Assemble: twiddles[0] = circle, twiddles[k] = line_twid_layers[k-1]
@@ -738,41 +730,58 @@ impl CircleTwiddles {
     }
 }
 
+fn assert_nonzero_twiddles(values: &[M31], context: &str) {
+    if let Some(idx) = values.iter().position(|value| value.is_zero()) {
+        panic!("{context} contains zero twiddle at index {idx}");
+    }
+}
+
+/// Computes the circle twiddle layer (layer 0) from the first line twiddle
+/// layer (layer 1), matching Stwo's `circle_twiddles_from_line_twiddles`.
+fn circle_twiddles_from_line_twiddles(first_line_twiddles: &[M31]) -> Vec<M31> {
+    assert!(
+        first_line_twiddles.len() >= 2 && first_line_twiddles.len() % 2 == 0,
+        "circle twiddle derivation requires an even first line twiddle layer of length >= 2"
+    );
+
+    let mut circle_twiddles = Vec::with_capacity(first_line_twiddles.len() * 2);
+    for chunk in first_line_twiddles.chunks_exact(2) {
+        let x = chunk[0];
+        let y = chunk[1];
+        circle_twiddles.extend([y, -y, -x, x]);
+    }
+    circle_twiddles
+}
+
 /// Batch multiplicative inverse using Montgomery's trick.
 ///
 /// Computes inverses of all elements in O(n) multiplications + 1 inversion.
-/// Elements that are zero get M31::ZERO as their "inverse".
+/// All inputs must be nonzero.
 fn batch_inverse(values: &[M31]) -> Vec<M31> {
     let n = values.len();
     if n == 0 {
         return vec![];
     }
 
+    assert_nonzero_twiddles(values, "batch_inverse inputs");
+
     // Forward pass: accumulate products
     let mut prefix = Vec::with_capacity(n);
     let mut acc = M31::ONE;
     for &v in values {
-        if v.is_zero() {
-            prefix.push(acc);
-        } else {
-            acc = acc * v;
-            prefix.push(acc);
-        }
+        acc = acc * v;
+        prefix.push(acc);
     }
 
     // Invert the accumulated product
-    let mut inv_acc = if acc.is_zero() { M31::ONE } else { acc.inv() };
+    let mut inv_acc = acc.inv();
 
     // Backward pass: extract individual inverses
     let mut result = vec![M31::ZERO; n];
     for i in (0..n).rev() {
-        if values[i].is_zero() {
-            result[i] = M31::ZERO;
-        } else {
-            let prev = if i == 0 { M31::ONE } else { prefix[i - 1] };
-            result[i] = inv_acc * prev;
-            inv_acc = inv_acc * values[i];
-        }
+        let prev = if i == 0 { M31::ONE } else { prefix[i - 1] };
+        result[i] = inv_acc * prev;
+        inv_acc = inv_acc * values[i];
     }
 
     result
@@ -787,7 +796,7 @@ fn batch_inverse(values: &[M31]) -> Vec<M31> {
 /// The domain is a canonic coset where point i and point i+N/2 are
 /// conjugates (same x, opposite y), enabling clean butterfly decomposition.
 ///
-/// Coefficients are stored in bit-reversed order of the basis index.
+/// Coefficients are stored in natural circle-basis order.
 #[derive(Clone, Debug)]
 pub struct FastCircleFFT {
     /// Precomputed twiddle factors.
@@ -969,8 +978,8 @@ impl FastCircleFFT {
 
     /// Forward FFT (evaluation): circle-basis coefficients → evaluations on coset domain.
     ///
-    /// Input: up to N coefficients in circle basis (bit-reversed order)
-    /// Output: N evaluations at the canonic coset points
+    /// Input: up to N coefficients in circle basis (natural order)
+    /// Output: N evaluations in bit-reversed canonic-domain order
     ///
     /// Structure (DIF - Decimation In Frequency):
     /// 1. Line layers (log_n-1 down to 1): x-coordinate butterflies
@@ -1034,8 +1043,8 @@ impl FastCircleFFT {
 
     /// Inverse FFT (interpolation): evaluations → circle-basis coefficients.
     ///
-    /// Input: N evaluations at the canonic coset points
-    /// Output: N coefficients in circle basis (bit-reversed order)
+    /// Input: N evaluations in bit-reversed canonic-domain order
+    /// Output: N coefficients in circle basis (natural order)
     ///
     /// Structure (DIT - Decimation In Time):
     /// 1. Circle layer (0): y-coordinate inverse butterflies
@@ -1135,12 +1144,14 @@ impl FastCircleFFT {
         self.twiddles.log_size
     }
 
-    /// Get the coset domain used by this FFT.
+    /// Get the canonic coset domain in circle-domain order.
+    ///
+    /// `fft()` outputs evaluations in bit-reversed order relative to this slice.
     pub fn domain(&self) -> &[CirclePoint] {
         &self.twiddles.coset_points
     }
 
-    /// Get point in the coset domain.
+    /// Get a point in the canonic coset domain order.
     #[inline]
     pub fn get_domain_point(&self, index: usize) -> CirclePoint {
         let n = self.size();
@@ -1731,7 +1742,7 @@ mod tests {
             let fast_fft = FastCircleFFT::new(log_size);
             let n = 1usize << log_size;
 
-            // Create N test coefficients (circle basis, bit-reversed order)
+            // Create N test coefficients (circle basis, natural order)
             let coeffs: Vec<M31> = (0..n).map(|i| M31::new((i * 7 + 13) as u32 % 1000)).collect();
 
             // Forward FFT: N coeffs -> N evals
@@ -1901,8 +1912,8 @@ mod tests {
         assert!(log_size >= 4, "reference recurrence is only used for log_size >= 4");
 
         let n = 1usize << log_size;
-        let mut initial = CirclePoint::generator(log_size + 2);
-        let mut step = CirclePoint::generator(log_size);
+        let mut initial = CirclePoint::generator(log_size + 1);
+        let mut step = CirclePoint::generator(log_size - 1);
         let mut coset_size = n / 2;
 
         let mut line_layers = Vec::with_capacity(log_size - 1);
@@ -1939,6 +1950,45 @@ mod tests {
         out
     }
 
+    fn eval_circle_basis_poly_at_point(coeffs: &[M31], point: CirclePoint, log_size: usize) -> M31 {
+        let mut maps = Vec::with_capacity(log_size);
+        if log_size > 0 {
+            maps.push(point.y);
+        }
+        if log_size > 1 {
+            let mut x = point.x;
+            maps.push(x);
+            for _ in 2..log_size {
+                x = x * x + x * x - M31::ONE;
+                maps.push(x);
+            }
+        }
+
+        let mut result = M31::ZERO;
+        for (store_idx, &coeff) in coeffs.iter().enumerate() {
+            let mut term = coeff;
+            for bit in 0..log_size {
+                if ((store_idx >> bit) & 1) == 1 {
+                    term = term * maps[bit];
+                }
+            }
+            result = result + term;
+        }
+        result
+    }
+
+    #[test]
+    fn test_fast_fft_twiddles_small_sizes_match_manual_schedule() {
+        let log_size_2 = CircleTwiddles::new(1);
+        let initial_2 = CirclePoint::generator(2);
+        assert_eq!(log_size_2.twiddles[0], vec![initial_2.y]);
+
+        let log_size_4 = CircleTwiddles::new(2);
+        let initial_4 = CirclePoint::generator(3);
+        assert_eq!(log_size_4.twiddles[0], vec![initial_4.y, -initial_4.y]);
+        assert_eq!(log_size_4.twiddles[1], vec![initial_4.x]);
+    }
+
     #[test]
     fn test_fast_fft_twiddles_match_reference_recurrence() {
         for log_size in 4..=10 {
@@ -1958,6 +2008,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "CircleTwiddles::new only supports log_size <= 30")]
+    fn test_fast_fft_rejects_oversized_canonic_domain() {
+        let _ = CircleTwiddles::new(31);
+    }
+
+    #[test]
+    #[should_panic(expected = "batch_inverse inputs contains zero twiddle")]
+    fn test_batch_inverse_rejects_zero_inputs() {
+        let _ = batch_inverse(&[M31::ONE, M31::ZERO]);
+    }
+
+    #[test]
     fn test_fast_fft_conjugate_domain_structure() {
         // Verify the domain has correct conjugate pairing:
         // domain[i] and domain[i+N/2] should have same x, opposite y
@@ -1974,6 +2036,26 @@ mod tests {
                 assert_eq!(domain[i].y, M31::ZERO - domain[i + half].y,
                     "y-coords should be opposite at ({}, {}) for log_size {}",
                     i, i + half, log_size);
+            }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_matches_direct_circle_basis_eval_in_bit_reversed_domain_order() {
+        for log_size in 1..=5 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+            let coeffs: Vec<M31> =
+                (0..n).map(|i| M31::new((i * 23 + 11) as u32 % 1000)).collect();
+
+            let evals = fft.fft(&coeffs);
+            for i in 0..n {
+                let point = fft.domain()[bit_reverse(i, log_size)];
+                let expected = eval_circle_basis_poly_at_point(&coeffs, point, log_size);
+                assert_eq!(
+                    evals[i], expected,
+                    "direct basis evaluation mismatch at log_size {log_size}, bit-reversed index {i}"
+                );
             }
         }
     }

--- a/crates/primitives/src/circle.rs
+++ b/crates/primitives/src/circle.rs
@@ -33,6 +33,9 @@
 //! - Stwo prover implementation
 
 use crate::field::M31;
+use crate::p3_interop::{from_p3, to_p3, P3M31};
+use p3_field::{Field, PackedValue};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -789,13 +792,179 @@ fn batch_inverse(values: &[M31]) -> Vec<M31> {
 pub struct FastCircleFFT {
     /// Precomputed twiddle factors.
     twiddles: CircleTwiddles,
+    /// Twiddle factors converted to Plonky3 Mersenne31 for packed SIMD path.
+    twiddles_p3: Vec<Vec<P3M31>>,
+    /// Inverse twiddle factors converted to Plonky3 Mersenne31 for packed SIMD path.
+    itwiddles_p3: Vec<Vec<P3M31>>,
+}
+
+const PARALLEL_LAYER_MIN_SIZE: usize = 1 << 12;
+const SIMD_PATH_MIN_SIZE: usize = 1 << 8;
+
+#[inline]
+fn should_parallelize(n: usize, num_blocks: usize) -> bool {
+    n >= PARALLEL_LAYER_MIN_SIZE && num_blocks > 1
+}
+
+#[inline]
+fn packed_width_p3() -> usize {
+    <<P3M31 as Field>::Packing as PackedValue>::WIDTH
+}
+
+#[inline]
+fn should_use_simd(n: usize) -> bool {
+    packed_width_p3() > 1 && n >= SIMD_PATH_MIN_SIZE
+}
+
+fn forward_layer_m31(values: &mut [M31], twids: &[M31], half_block: usize) {
+    let block_size = half_block * 2;
+    debug_assert_eq!(values.len(), twids.len() * block_size);
+
+    if should_parallelize(values.len(), twids.len()) {
+        values
+            .par_chunks_mut(block_size)
+            .zip(twids.par_iter().copied())
+            .for_each(|(chunk, t)| {
+                let (lo, hi) = chunk.split_at_mut(half_block);
+                for i in 0..half_block {
+                    let tmp = hi[i] * t;
+                    hi[i] = lo[i] - tmp;
+                    lo[i] = lo[i] + tmp;
+                }
+            });
+    } else {
+        for (chunk, &t) in values.chunks_mut(block_size).zip(twids.iter()) {
+            let (lo, hi) = chunk.split_at_mut(half_block);
+            for i in 0..half_block {
+                let tmp = hi[i] * t;
+                hi[i] = lo[i] - tmp;
+                lo[i] = lo[i] + tmp;
+            }
+        }
+    }
+}
+
+fn inverse_layer_m31(values: &mut [M31], itwids: &[M31], half_block: usize) {
+    let block_size = half_block * 2;
+    debug_assert_eq!(values.len(), itwids.len() * block_size);
+
+    if should_parallelize(values.len(), itwids.len()) {
+        values
+            .par_chunks_mut(block_size)
+            .zip(itwids.par_iter().copied())
+            .for_each(|(chunk, it)| {
+                let (lo, hi) = chunk.split_at_mut(half_block);
+                for i in 0..half_block {
+                    let tmp = lo[i];
+                    lo[i] = tmp + hi[i];
+                    hi[i] = (tmp - hi[i]) * it;
+                }
+            });
+    } else {
+        for (chunk, &it) in values.chunks_mut(block_size).zip(itwids.iter()) {
+            let (lo, hi) = chunk.split_at_mut(half_block);
+            for i in 0..half_block {
+                let tmp = lo[i];
+                lo[i] = tmp + hi[i];
+                hi[i] = (tmp - hi[i]) * it;
+            }
+        }
+    }
+}
+
+#[inline]
+fn dit_block_p3(lo: &mut [P3M31], hi: &mut [P3M31], twid: P3M31) {
+    debug_assert_eq!(lo.len(), hi.len());
+
+    let (lo_packed, lo_suffix) = <P3M31 as Field>::Packing::pack_slice_with_suffix_mut(lo);
+    let (hi_packed, hi_suffix) = <P3M31 as Field>::Packing::pack_slice_with_suffix_mut(hi);
+
+    for (a, b) in lo_packed.iter_mut().zip(hi_packed.iter_mut()) {
+        let tmp = *b * twid;
+        *b = *a - tmp;
+        *a = *a + tmp;
+    }
+    for (a, b) in lo_suffix.iter_mut().zip(hi_suffix.iter_mut()) {
+        let tmp = *b * twid;
+        *b = *a - tmp;
+        *a = *a + tmp;
+    }
+}
+
+#[inline]
+fn idit_block_p3(lo: &mut [P3M31], hi: &mut [P3M31], itwid: P3M31) {
+    debug_assert_eq!(lo.len(), hi.len());
+
+    let (lo_packed, lo_suffix) = <P3M31 as Field>::Packing::pack_slice_with_suffix_mut(lo);
+    let (hi_packed, hi_suffix) = <P3M31 as Field>::Packing::pack_slice_with_suffix_mut(hi);
+
+    for (a, b) in lo_packed.iter_mut().zip(hi_packed.iter_mut()) {
+        let tmp = *a;
+        *a = tmp + *b;
+        *b = (tmp - *b) * itwid;
+    }
+    for (a, b) in lo_suffix.iter_mut().zip(hi_suffix.iter_mut()) {
+        let tmp = *a;
+        *a = tmp + *b;
+        *b = (tmp - *b) * itwid;
+    }
+}
+
+fn forward_layer_p3(values: &mut [P3M31], twids: &[P3M31], half_block: usize) {
+    let block_size = half_block * 2;
+    debug_assert_eq!(values.len(), twids.len() * block_size);
+
+    if should_parallelize(values.len(), twids.len()) {
+        values
+            .par_chunks_mut(block_size)
+            .zip(twids.par_iter().copied())
+            .for_each(|(chunk, t)| {
+                let (lo, hi) = chunk.split_at_mut(half_block);
+                dit_block_p3(lo, hi, t);
+            });
+    } else {
+        for (chunk, &t) in values.chunks_mut(block_size).zip(twids.iter()) {
+            let (lo, hi) = chunk.split_at_mut(half_block);
+            dit_block_p3(lo, hi, t);
+        }
+    }
+}
+
+fn inverse_layer_p3(values: &mut [P3M31], itwids: &[P3M31], half_block: usize) {
+    let block_size = half_block * 2;
+    debug_assert_eq!(values.len(), itwids.len() * block_size);
+
+    if should_parallelize(values.len(), itwids.len()) {
+        values
+            .par_chunks_mut(block_size)
+            .zip(itwids.par_iter().copied())
+            .for_each(|(chunk, it)| {
+                let (lo, hi) = chunk.split_at_mut(half_block);
+                idit_block_p3(lo, hi, it);
+            });
+    } else {
+        for (chunk, &it) in values.chunks_mut(block_size).zip(itwids.iter()) {
+            let (lo, hi) = chunk.split_at_mut(half_block);
+            idit_block_p3(lo, hi, it);
+        }
+    }
 }
 
 impl FastCircleFFT {
     /// Create a Fast Circle FFT for domain size 2^log_size.
     pub fn new(log_size: usize) -> Self {
         let twiddles = CircleTwiddles::new(log_size);
-        Self { twiddles }
+        let twiddles_p3 = twiddles
+            .twiddles
+            .iter()
+            .map(|layer| layer.iter().copied().map(to_p3).collect())
+            .collect();
+        let itwiddles_p3 = twiddles
+            .itwiddles
+            .iter()
+            .map(|layer| layer.iter().copied().map(to_p3).collect())
+            .collect();
+        Self { twiddles, twiddles_p3, itwiddles_p3 }
     }
 
     /// Forward FFT (evaluation): circle-basis coefficients → evaluations on coset domain.
@@ -807,6 +976,15 @@ impl FastCircleFFT {
     /// 1. Line layers (log_n-1 down to 1): x-coordinate butterflies
     /// 2. Circle layer (0): y-coordinate butterflies
     pub fn fft(&self, coeffs: &[M31]) -> Vec<M31> {
+        let n = self.size();
+        if should_use_simd(n) {
+            self.fft_packed_simd(coeffs)
+        } else {
+            self.fft_scalar_parallel(coeffs)
+        }
+    }
+
+    fn fft_scalar_parallel(&self, coeffs: &[M31]) -> Vec<M31> {
         let log_n = self.twiddles.log_size;
         if log_n == 0 {
             return if coeffs.is_empty() { vec![M31::ZERO] } else { vec![coeffs[0]] };
@@ -824,36 +1002,34 @@ impl FastCircleFFT {
         //
         // Line layers: k = log_n-1 down to 1 (x-coordinate twiddles)
         for layer in (1..log_n).rev() {
-            let twids = &self.twiddles.twiddles[layer];
-            let half_block = 1usize << layer;
-            let block_size = half_block * 2;
-
-            for (h, &t) in twids.iter().enumerate() {
-                let base = h * block_size;
-                for l in 0..half_block {
-                    let idx0 = base + l;
-                    let idx1 = idx0 + half_block;
-                    let tmp = values[idx1] * t;
-                    values[idx1] = values[idx0] - tmp;
-                    values[idx0] = values[idx0] + tmp;
-                }
-            }
+            forward_layer_m31(&mut values, &self.twiddles.twiddles[layer], 1usize << layer);
         }
 
         // Circle layer (layer 0): y-coordinate twiddles
-        // half_block = 1, block_size = 2, operates on pairs (2h, 2h+1)
-        {
-            let twids = &self.twiddles.twiddles[0];
-            for (h, &t) in twids.iter().enumerate() {
-                let idx0 = 2 * h;
-                let idx1 = idx0 + 1;
-                let tmp = values[idx1] * t;
-                values[idx1] = values[idx0] - tmp;
-                values[idx0] = values[idx0] + tmp;
-            }
-        }
+        forward_layer_m31(&mut values, &self.twiddles.twiddles[0], 1);
 
         values
+    }
+
+    fn fft_packed_simd(&self, coeffs: &[M31]) -> Vec<M31> {
+        let log_n = self.twiddles.log_size;
+        if log_n == 0 {
+            return if coeffs.is_empty() { vec![M31::ZERO] } else { vec![coeffs[0]] };
+        }
+
+        let n = 1usize << log_n;
+        let mut values = vec![to_p3(M31::ZERO); n];
+        let copy_len = coeffs.len().min(n);
+        for i in 0..copy_len {
+            values[i] = to_p3(coeffs[i]);
+        }
+
+        for layer in (1..log_n).rev() {
+            forward_layer_p3(&mut values, &self.twiddles_p3[layer], 1usize << layer);
+        }
+        forward_layer_p3(&mut values, &self.twiddles_p3[0], 1);
+
+        values.into_iter().map(from_p3).collect()
     }
 
     /// Inverse FFT (interpolation): evaluations → circle-basis coefficients.
@@ -866,6 +1042,15 @@ impl FastCircleFFT {
     /// 2. Line layers (1 up to log_n-1): x-coordinate inverse butterflies
     /// 3. Normalize by 1/N
     pub fn ifft(&self, evals: &[M31]) -> Vec<M31> {
+        let n = self.size();
+        if should_use_simd(n) {
+            self.ifft_packed_simd(evals)
+        } else {
+            self.ifft_scalar_parallel(evals)
+        }
+    }
+
+    fn ifft_scalar_parallel(&self, evals: &[M31]) -> Vec<M31> {
         let log_n = self.twiddles.log_size;
         if log_n == 0 {
             return evals.to_vec();
@@ -880,42 +1065,52 @@ impl FastCircleFFT {
         // Layer k has half_block = 2^k, block_size = 2^{k+1}, num_twiddles = N/2^{k+1}
 
         // Circle layer (layer 0): y-coordinate inverse twiddles on pairs (2h, 2h+1)
-        {
-            let itwids = &self.twiddles.itwiddles[0];
-            for (h, &it) in itwids.iter().enumerate() {
-                let idx0 = 2 * h;
-                let idx1 = idx0 + 1;
-                let tmp = values[idx0];
-                values[idx0] = tmp + values[idx1];
-                values[idx1] = (tmp - values[idx1]) * it;
-            }
-        }
+        inverse_layer_m31(&mut values, &self.twiddles.itwiddles[0], 1);
 
         // Line layers: k = 1 up to log_n-1 (x-coordinate inverse twiddles)
         for layer in 1..log_n {
-            let itwids = &self.twiddles.itwiddles[layer];
-            let half_block = 1usize << layer;
-            let block_size = half_block * 2;
-
-            for (h, &it) in itwids.iter().enumerate() {
-                let base = h * block_size;
-                for l in 0..half_block {
-                    let idx0 = base + l;
-                    let idx1 = idx0 + half_block;
-                    let tmp = values[idx0];
-                    values[idx0] = tmp + values[idx1];
-                    values[idx1] = (tmp - values[idx1]) * it;
-                }
-            }
+            inverse_layer_m31(&mut values, &self.twiddles.itwiddles[layer], 1usize << layer);
         }
 
         // Normalize by 1/N
         let n_inv = M31::new(n as u32).inv();
-        for v in &mut values {
-            *v = *v * n_inv;
+        if should_parallelize(n, n) {
+            values.par_iter_mut().for_each(|v| *v = *v * n_inv);
+        } else {
+            for v in &mut values {
+                *v = *v * n_inv;
+            }
         }
 
         values
+    }
+
+    fn ifft_packed_simd(&self, evals: &[M31]) -> Vec<M31> {
+        let log_n = self.twiddles.log_size;
+        if log_n == 0 {
+            return evals.to_vec();
+        }
+
+        let n = 1usize << log_n;
+        assert_eq!(evals.len(), n, "Evaluation count must match domain size");
+
+        let mut values: Vec<P3M31> = evals.iter().copied().map(to_p3).collect();
+
+        inverse_layer_p3(&mut values, &self.itwiddles_p3[0], 1);
+        for layer in 1..log_n {
+            inverse_layer_p3(&mut values, &self.itwiddles_p3[layer], 1usize << layer);
+        }
+
+        let n_inv = to_p3(M31::new(n as u32).inv());
+        if should_parallelize(n, n) {
+            values.par_iter_mut().for_each(|v| *v = *v * n_inv);
+        } else {
+            for v in &mut values {
+                *v = *v * n_inv;
+            }
+        }
+
+        values.into_iter().map(from_p3).collect()
     }
 
     /// Low-degree extension: extend evaluations to a larger domain.
@@ -1555,6 +1750,32 @@ mod tests {
                     i, log_size, recovered[i].value(), coeffs[i].value()
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_fast_fft_scalar_and_packed_paths_match() {
+        for log_size in 2..=8 {
+            let fft = FastCircleFFT::new(log_size);
+            let n = 1usize << log_size;
+            let coeffs: Vec<M31> =
+                (0..n).map(|i| M31::new((i * 19 + 7) as u32 % 1_000_000)).collect();
+
+            let evals_scalar = fft.fft_scalar_parallel(&coeffs);
+            let evals_packed = fft.fft_packed_simd(&coeffs);
+            assert_eq!(
+                evals_scalar, evals_packed,
+                "FFT path mismatch for log_size {}",
+                log_size
+            );
+
+            let recovered_scalar = fft.ifft_scalar_parallel(&evals_scalar);
+            let recovered_packed = fft.ifft_packed_simd(&evals_scalar);
+            assert_eq!(
+                recovered_scalar, recovered_packed,
+                "IFFT path mismatch for log_size {}",
+                log_size
+            );
         }
     }
 

--- a/crates/primitives/src/circle.rs
+++ b/crates/primitives/src/circle.rs
@@ -1770,10 +1770,15 @@ mod tests {
             );
 
             let recovered_scalar = fft.ifft_scalar_parallel(&evals_scalar);
-            let recovered_packed = fft.ifft_packed_simd(&evals_scalar);
+            let recovered_packed = fft.ifft_packed_simd(&evals_packed);
             assert_eq!(
                 recovered_scalar, recovered_packed,
                 "IFFT path mismatch for log_size {}",
+                log_size
+            );
+            assert_eq!(
+                recovered_packed, coeffs,
+                "Packed end-to-end roundtrip mismatch for log_size {}",
                 log_size
             );
         }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,5 +17,5 @@ pub mod p3_interop;
 pub use field::M31;
 pub use extension::{CM31, QM31, U_SQUARED};
 pub use limbs::{to_limbs, from_limbs};
-pub use circle::{CirclePoint, CircleDomain, CircleFFT, Coset, FastCircleFFT};
+pub use circle::{CirclePoint, CircleDomain, CircleFFT, Coset, FastCircleFFT, CircleTwiddles};
 pub use p3_interop::{to_p3, from_p3, P3M31};

--- a/crates/prover/src/fri.rs
+++ b/crates/prover/src/fri.rs
@@ -17,7 +17,7 @@
 //!
 //! This halves both the domain size and polynomial degree.
 
-use zp1_primitives::M31;
+use zp1_primitives::{CirclePoint, M31};
 use crate::channel::ProverChannel;
 use crate::commitment::MerkleTree;
 
@@ -159,6 +159,24 @@ pub struct FriProver {
     config: FriConfig,
 }
 
+#[inline]
+fn fold_conjugate_pair(f_pos: M31, f_neg: M31, alpha: M31, y_i: M31, inv_two: M31) -> M31 {
+    let sum = f_pos + f_neg;
+    let diff = f_pos - f_neg;
+    if y_i.is_zero() {
+        sum * inv_two
+    } else {
+        sum * inv_two + alpha * diff * inv_two * y_i.inv()
+    }
+}
+
+#[inline]
+fn canonic_pair_y(layer_log_size: usize, pair_idx: usize) -> M31 {
+    let initial = CirclePoint::generator(layer_log_size + 2);
+    let step = CirclePoint::generator(layer_log_size);
+    initial.mul(step.pow(pair_idx as u64)).y
+}
+
 impl FriProver {
     /// Create a new FRI prover with the given configuration.
     pub fn new(config: FriConfig) -> Self {
@@ -221,53 +239,35 @@ impl FriProver {
 
     /// Circle FRI folding: fold polynomial using twin-coset structure.
     ///
-    /// For points at indices i and i + n/2 (which are twins on the circle),
-    /// we compute:
+    /// Evaluations come from the canonic coset domain where evals[i] and
+    /// evals[i + n/2] correspond to conjugate points (x, y) and (x, -y).
+    /// We compute:
     /// - f_folded[i] = (f[i] + f[i + n/2]) / 2 + alpha * (f[i] - f[i + n/2]) / (2 * y_i)
     ///
     /// This halves the domain size while maintaining the RS proximity property.
     fn fold_circle(&self, evals: &[M31], alpha: M31, layer: usize) -> Vec<M31> {
-        use zp1_primitives::CirclePoint;
-        
         let n = evals.len();
         let half_n = n / 2;
         let mut folded = Vec::with_capacity(half_n);
 
-        // Two inverse constant
-        let two = M31::new(2);
-        let inv_two = two.inv();
+        let inv_two = M31::new(2).inv();
 
-        // Get the circle domain generator for current layer
-        // Domain size at this layer = 2^(log_domain_size - layer)
+        // Build the same coset that FastCircleFFT uses for this layer's domain size.
+        // Coset: initial = generator(log_n + 2), step = generator(log_n)
         let layer_log_size = self.config.log_domain_size.saturating_sub(layer);
-        let generator = CirclePoint::generator(layer_log_size);
+        let initial = CirclePoint::generator(layer_log_size + 2);
+        let step = CirclePoint::generator(layer_log_size);
 
+        let mut point = initial;
         for i in 0..half_n {
             let f_pos = evals[i];
             let f_neg = evals[i + half_n];
 
-            // Sum and difference
-            let sum = f_pos + f_neg;
-            let diff = f_pos - f_neg;
+            let y_i = point.y;
+            let folded_val = fold_conjugate_pair(f_pos, f_neg, alpha, y_i, inv_two);
 
-            // Get y-coordinate of domain point i
-            // point_i = generator^i
-            let point_i = generator.pow(i as u64);
-            let y_i = point_i.y;
-            
-            // Proper Circle FRI folding formula:
-            // f_folded = (sum / 2) + alpha * (diff / (2 * y_i))
-            // = (sum / 2) + alpha * diff * inv_two * y_i^(-1)
-            let folded_val = if y_i.is_zero() {
-                // Edge case: y = 0 means we're at (1,0) or (-1,0)
-                // Just use the sum part
-                sum * inv_two
-            } else {
-                let y_inv = y_i.inv();
-                sum * inv_two + alpha * diff * inv_two * y_inv
-            };
-            
             folded.push(folded_val);
+            point = point.mul(step);
         }
 
         folded
@@ -306,8 +306,8 @@ impl FriProver {
                         merkle_proof,
                     });
 
-                    // Update index for next layer (halve it)
-                    current_idx /= 2;
+                    // Folded index is the conjugate-pair index in the first half.
+                    current_idx %= n / 2;
                 }
 
                 FriQueryProof {
@@ -364,12 +364,22 @@ impl FriProver {
                 // Compute expected folded value for next layer
                 let alpha = challenges[layer_idx];
                 let inv_two = M31::new(2).inv();
-                let sum = layer_proof.value + layer_proof.sibling_value;
-                let diff = layer_proof.value - layer_proof.sibling_value;
-                let folded = sum * inv_two + alpha * diff * inv_two;
+                let layer_log_size = self.config.log_domain_size.saturating_sub(layer_idx);
+                let layer_n = 1usize << layer_log_size;
+                let half_n = layer_n / 2;
+
+                let pair_idx = current_idx % half_n;
+                let y_i = canonic_pair_y(layer_log_size, pair_idx);
+
+                let (f_pos, f_neg) = if current_idx < half_n {
+                    (layer_proof.value, layer_proof.sibling_value)
+                } else {
+                    (layer_proof.sibling_value, layer_proof.value)
+                };
+                let folded = fold_conjugate_pair(f_pos, f_neg, alpha, y_i, inv_two);
                 
                 expected_value = Some(folded);
-                current_idx /= 2;
+                current_idx = pair_idx;
             }
             
             // Verify final value matches final polynomial evaluation
@@ -418,6 +428,36 @@ mod tests {
         // Verify folding is deterministic
         let folded2 = prover.fold_circle(&evals, alpha, 0);
         assert_eq!(folded, folded2);
+    }
+
+    #[test]
+    fn test_fri_fold_pair_index_orientation_invariant() {
+        let prover = FriProver::new(FriConfig::new(4));
+        let evals: Vec<M31> = (0..16).map(|i| M31::new((i * 17 + 9) as u32)).collect();
+        let alpha = M31::new(7);
+        let folded = prover.fold_circle(&evals, alpha, 0);
+
+        let n = evals.len();
+        let half_n = n / 2;
+        let inv_two = M31::new(2).inv();
+
+        for idx in 0..n {
+            let pair_idx = idx % half_n;
+            let sibling_idx = (idx + half_n) % n;
+            let y_i = canonic_pair_y(4, pair_idx);
+
+            let (f_pos, f_neg) = if idx < half_n {
+                (evals[idx], evals[sibling_idx])
+            } else {
+                (evals[sibling_idx], evals[idx])
+            };
+
+            let folded_val = fold_conjugate_pair(f_pos, f_neg, alpha, y_i, inv_two);
+            assert_eq!(
+                folded_val, folded[pair_idx],
+                "Fold mismatch for idx {idx} (pair_idx {pair_idx})"
+            );
+        }
     }
 
     #[test]

--- a/crates/prover/src/fri.rs
+++ b/crates/prover/src/fri.rs
@@ -17,6 +17,8 @@
 //!
 //! This halves both the domain size and polynomial degree.
 
+use std::collections::HashMap;
+
 use zp1_primitives::{CirclePoint, M31};
 use crate::channel::ProverChannel;
 use crate::commitment::MerkleTree;
@@ -45,6 +47,17 @@ pub enum SecurityLevel {
     Bits128,
 }
 
+const MAX_FRI_CIRCLE_LOG_SIZE: usize = 30;
+
+#[inline]
+fn assert_supported_fri_log_size(log_domain_size: usize, context: &str) {
+    assert!(
+        log_domain_size <= MAX_FRI_CIRCLE_LOG_SIZE,
+        "{context} only supports log_domain_size <= {} because canonic Circle FRI requires CirclePoint::generator(log_domain_size + 1) <= 31",
+        MAX_FRI_CIRCLE_LOG_SIZE
+    );
+}
+
 impl FriConfig {
     /// Create a default FRI configuration (100-bit security).
     pub fn new(log_domain_size: usize) -> Self {
@@ -53,6 +66,7 @@ impl FriConfig {
     
     /// Create a FRI configuration with specified security level.
     pub fn with_security(log_domain_size: usize, level: SecurityLevel) -> Self {
+        assert_supported_fri_log_size(log_domain_size, "FriConfig");
         let num_queries = match level {
             SecurityLevel::Bits80 => 40,   // ~80 bits from FRI
             SecurityLevel::Bits100 => 50,  // ~100 bits from FRI  
@@ -69,6 +83,7 @@ impl FriConfig {
     
     /// Create a fast configuration for testing (reduced security).
     pub fn fast(log_domain_size: usize) -> Self {
+        assert_supported_fri_log_size(log_domain_size, "FriConfig");
         Self {
             log_domain_size,
             folding_factor: 2,
@@ -171,15 +186,32 @@ fn fold_conjugate_pair(f_pos: M31, f_neg: M31, alpha: M31, y_i: M31, inv_two: M3
 }
 
 #[inline]
-fn canonic_pair_y(layer_log_size: usize, pair_idx: usize) -> M31 {
-    let initial = CirclePoint::generator(layer_log_size + 2);
-    let step = CirclePoint::generator(layer_log_size);
+fn canonic_layer_generators(
+    layer_log_size: usize,
+    context: &str,
+) -> (usize, CirclePoint, CirclePoint) {
+    assert_supported_fri_log_size(layer_log_size, context);
+    assert!(layer_log_size > 0, "{context} requires layer_log_size > 0");
+
+    let half_n = 1usize << (layer_log_size - 1);
+    let initial = CirclePoint::generator(layer_log_size + 1);
+    let step = if layer_log_size == 1 {
+        CirclePoint::IDENTITY
+    } else {
+        CirclePoint::generator(layer_log_size - 1)
+    };
+    (half_n, initial, step)
+}
+
+#[inline]
+fn canonic_pair_y(initial: CirclePoint, step: CirclePoint, pair_idx: usize) -> M31 {
     initial.mul(step.pow(pair_idx as u64)).y
 }
 
 impl FriProver {
     /// Create a new FRI prover with the given configuration.
     pub fn new(config: FriConfig) -> Self {
+        assert_supported_fri_log_size(config.log_domain_size, "FriProver");
         Self { config }
     }
 
@@ -252,11 +284,10 @@ impl FriProver {
 
         let inv_two = M31::new(2).inv();
 
-        // Build the same coset that FastCircleFFT uses for this layer's domain size.
-        // Coset: initial = generator(log_n + 2), step = generator(log_n)
         let layer_log_size = self.config.log_domain_size.saturating_sub(layer);
-        let initial = CirclePoint::generator(layer_log_size + 2);
-        let step = CirclePoint::generator(layer_log_size);
+        let (expected_half_n, initial, step) =
+            canonic_layer_generators(layer_log_size, "FRI folding");
+        debug_assert_eq!(expected_half_n, half_n);
 
         let mut point = initial;
         for i in 0..half_n {
@@ -340,6 +371,20 @@ impl FriProver {
             self.config.num_queries,
             1 << self.config.log_domain_size,
         );
+        let inv_two = M31::new(2).inv();
+        let layer_geometry: Vec<_> = proof
+            .layer_commitments
+            .iter()
+            .enumerate()
+            .map(|(layer_idx, _)| {
+                canonic_layer_generators(
+                    self.config.log_domain_size.saturating_sub(layer_idx),
+                    "FRI verification",
+                )
+            })
+            .collect();
+        let mut layer_y_cache: Vec<HashMap<usize, M31>> =
+            (0..layer_geometry.len()).map(|_| HashMap::new()).collect();
         
         for (query_idx, query_proof) in proof.query_proofs.iter().enumerate() {
             if query_proof.index != query_indices[query_idx] {
@@ -363,13 +408,12 @@ impl FriProver {
                 
                 // Compute expected folded value for next layer
                 let alpha = challenges[layer_idx];
-                let inv_two = M31::new(2).inv();
-                let layer_log_size = self.config.log_domain_size.saturating_sub(layer_idx);
-                let layer_n = 1usize << layer_log_size;
-                let half_n = layer_n / 2;
+                let (half_n, initial, step) = layer_geometry[layer_idx];
 
                 let pair_idx = current_idx % half_n;
-                let y_i = canonic_pair_y(layer_log_size, pair_idx);
+                let y_i = *layer_y_cache[layer_idx]
+                    .entry(pair_idx)
+                    .or_insert_with(|| canonic_pair_y(initial, step, pair_idx));
 
                 let (f_pos, f_neg) = if current_idx < half_n {
                     (layer_proof.value, layer_proof.sibling_value)
@@ -440,11 +484,12 @@ mod tests {
         let n = evals.len();
         let half_n = n / 2;
         let inv_two = M31::new(2).inv();
+        let (_, initial, step) = canonic_layer_generators(4, "FRI test");
 
         for idx in 0..n {
             let pair_idx = idx % half_n;
             let sibling_idx = (idx + half_n) % n;
-            let y_i = canonic_pair_y(4, pair_idx);
+            let y_i = canonic_pair_y(initial, step, pair_idx);
 
             let (f_pos, f_neg) = if idx < half_n {
                 (evals[idx], evals[sibling_idx])
@@ -525,5 +570,22 @@ mod tests {
         
         // Final poly should be small
         assert!(proof.final_poly.len() <= config.final_degree * 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "FriConfig only supports log_domain_size <= 30")]
+    fn test_fri_config_rejects_oversized_canonic_domain() {
+        let _ = FriConfig::new(31);
+    }
+
+    #[test]
+    #[should_panic(expected = "FriProver only supports log_domain_size <= 30")]
+    fn test_fri_prover_rejects_manual_oversized_config() {
+        let _ = FriProver::new(FriConfig {
+            log_domain_size: 31,
+            folding_factor: 2,
+            num_queries: 10,
+            final_degree: 8,
+        });
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the CircleFFT optimization end-to-end and wires it into the prover path.

### What changed
- Implemented true butterfly-based `FastCircleFFT` (`O(N log N)`) instead of the previous quadratic behavior.
- Added Rayon layer parallelism for butterfly passes (`par_chunks_mut`), so independent butterfly blocks run concurrently.
- Added SIMD path using Plonky3 packed M31 (`P3M31::Packing`) for vectorized butterfly math.
- Added dynamic path selection to avoid overhead on tiny inputs.
- Added coverage to ensure scalar and packed paths match.

## Performance

Comparison baseline:
- `main` (`f3c0335`): `CircleFFT`
- this branch (`ab8ee00`): optimized `FastCircleFFT` (butterfly + Rayon + SIMD)

Method:
- release mode benchmark (`cargo run --release`)
- median of 9 samples per op/size
- deterministic input generation

| Size | FFT main (us) | FFT optimized (us) | FFT speedup | IFFT main (us) | IFFT optimized (us) | IFFT speedup |
|---|---:|---:|---:|---:|---:|---:|
| 2^8 (256) | 117.322 | 0.646 | 181.71x | 2753.752 | 0.836 | 3295.58x |
| 2^10 (1024) | 1938.027 | 2.515 | 770.66x | 174322.646 | 2.936 | 59369.93x |
| 2^12 (4096) | 31075.449 | 242.615 | 128.09x | 10976366.500 | 276.831 | 39650.02x |

Geomean speedup:
- FFT: **261.77x**
- IFFT: **19796.14x**

## References used for implementation

### Circle FFT / butterfly structure (Stwo)
- https://github.com/starkware-libs/stwo/blob/main/crates/prover/src/core/poly/circle/ops.rs
- https://github.com/starkware-libs/stwo/blob/main/crates/prover/src/core/poly/twiddles.rs
- https://github.com/starkware-libs/stwo/blob/main/crates/prover/src/core/backend/simd/circle.rs

### SIMD packed field interfaces (Plonky3)
- https://github.com/Plonky3/Plonky3/blob/main/field/src/field.rs
- https://github.com/Plonky3/Plonky3/blob/main/field/src/packed/packed_traits.rs
